### PR TITLE
[#27] AssetViewModel 로직 수정, 자산 상세 화면 진입 시 TextField에 자산명이 입력되어 있지 않는 문제

### DIFF
--- a/core/data/src/main/java/com/sdhong/jonbeowin/core/data/impl/AssetRepositoryImpl.kt
+++ b/core/data/src/main/java/com/sdhong/jonbeowin/core/data/impl/AssetRepositoryImpl.kt
@@ -6,7 +6,6 @@ import com.sdhong.jonbeowin.core.data.mapper.toDomain
 import com.sdhong.jonbeowin.core.domain.model.Asset
 import com.sdhong.jonbeowin.core.domain.repository.AssetRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -21,9 +20,7 @@ internal class AssetRepositoryImpl @Inject constructor(
             }
         }
 
-    override fun getAsset(assetId: Int): Flow<Asset> = flow {
-        emit(assetLocalDataSource.getAsset(assetId))
-    }.map { it.toDomain() }
+    override fun getAsset(assetId: Int): Flow<Asset> = assetLocalDataSource.getAsset(assetId).map { it.toDomain() }
 
     override suspend fun updateAsset(asset: Asset) = assetLocalDataSource.updateAsset(asset.toData())
 

--- a/core/data/src/main/java/com/sdhong/jonbeowin/core/data/local/AssetLocalDataSource.kt
+++ b/core/data/src/main/java/com/sdhong/jonbeowin/core/data/local/AssetLocalDataSource.kt
@@ -7,7 +7,7 @@ interface AssetLocalDataSource {
 
     fun getAllAssets(): Flow<List<AssetEntity>>
 
-    suspend fun getAsset(assetId: Int): AssetEntity
+    fun getAsset(assetId: Int): Flow<AssetEntity>
 
     suspend fun updateAsset(asset: AssetEntity)
 

--- a/core/local/src/main/java/com/sdhong/jonbeowin/core/local/impl/AssetLocalDataSourceImpl.kt
+++ b/core/local/src/main/java/com/sdhong/jonbeowin/core/local/impl/AssetLocalDataSourceImpl.kt
@@ -18,7 +18,7 @@ internal class AssetLocalDataSourceImpl @Inject constructor(
             list.map { it.toData() }
         }
 
-    override suspend fun getAsset(assetId: Int): AssetEntity = assetDao.getAsset(assetId).toData()
+    override fun getAsset(assetId: Int): Flow<AssetEntity> = assetDao.getAsset(assetId).map { it.toData() }
 
     override suspend fun updateAsset(asset: AssetEntity) = assetDao.update(asset.toLocal())
 

--- a/core/local/src/main/java/com/sdhong/jonbeowin/core/local/room/dao/AssetDao.kt
+++ b/core/local/src/main/java/com/sdhong/jonbeowin/core/local/room/dao/AssetDao.kt
@@ -14,7 +14,7 @@ interface AssetDao {
     fun getAllAssets(): Flow<List<AssetLocal>>
 
     @Query("SELECT * FROM ${RoomConstant.Table.ASSET} WHERE id = :assetId")
-    suspend fun getAsset(assetId: Int): AssetLocal
+    fun getAsset(assetId: Int): Flow<AssetLocal>
 
     @Upsert
     suspend fun update(asset: AssetLocal)

--- a/feature/asset/src/main/java/com/sdhong/jonbeowin/feature/asset/component/AssetContent.kt
+++ b/feature/asset/src/main/java/com/sdhong/jonbeowin/feature/asset/component/AssetContent.kt
@@ -8,10 +8,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
@@ -19,83 +15,46 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.sdhong.jonbeowin.feature.asset.R
+import com.sdhong.jonbeowin.feature.asset.model.BuyDateModel
 import com.sdhong.jonbeowin.feature.asset.uistate.AssetUiState
 
 @Composable
 internal fun AssetContent(
     uiState: AssetUiState,
     @StringRes buttonTextId: Int,
+    onAssetNameChange: (String) -> Unit,
     onClickBuyDate: () -> Unit,
     onClickConfirm: (String) -> Unit
 ) {
-    var assetName by rememberSaveable { mutableStateOf("") }
-
     when (uiState) {
         AssetUiState.Idle -> Unit
 
-        is AssetUiState.AssetDetailInitial -> {
-            assetName = uiState.initialAsset.name
-            val buyDate = uiState.initialAsset.buyDate
+        is AssetUiState.Success -> {
+            val name = uiState.asset.name
+            val buyDate = uiState.asset.buyDate
 
             Column(
                 modifier = Modifier.fillMaxSize().padding(16.dp),
                 verticalArrangement = Arrangement.SpaceBetween
             ) {
                 AssetCard(
-                    assetName = assetName,
-                    onAssetNameChange = { assetName = it },
-                    buyDateText = stringResource(
-                        R.string.date_format,
-                        buyDate.year,
-                        buyDate.month,
-                        buyDate.day
-                    ),
+                    assetName = name,
+                    onAssetNameChange = onAssetNameChange,
+                    buyDateText = if (buyDate == BuyDateModel.Default) {
+                        stringResource(R.string.choose_date)
+                    } else {
+                        stringResource(
+                            R.string.date_format,
+                            buyDate.year,
+                            buyDate.month,
+                            buyDate.day
+                        )
+                    },
                     onClickBuyDate = onClickBuyDate
                 )
                 AssetConfirmButton(
                     buttonTextId = buttonTextId,
-                    onClickConfirm = { onClickConfirm(assetName) }
-                )
-            }
-        }
-
-        AssetUiState.AddAssetInitial -> {
-            Column(
-                modifier = Modifier.fillMaxSize().padding(16.dp),
-                verticalArrangement = Arrangement.SpaceBetween
-            ) {
-                AssetCard(
-                    assetName = assetName,
-                    onAssetNameChange = { assetName = it },
-                    buyDateText = stringResource(R.string.choose_date),
-                    onClickBuyDate = onClickBuyDate
-                )
-                AssetConfirmButton(
-                    buttonTextId = buttonTextId,
-                    onClickConfirm = { onClickConfirm(assetName) }
-                )
-            }
-        }
-
-        is AssetUiState.AssetDateSelected -> {
-            Column(
-                modifier = Modifier.fillMaxSize().padding(16.dp),
-                verticalArrangement = Arrangement.SpaceBetween
-            ) {
-                AssetCard(
-                    assetName = assetName,
-                    onAssetNameChange = { assetName = it },
-                    buyDateText = stringResource(
-                        R.string.date_format,
-                        uiState.buyDate.year,
-                        uiState.buyDate.month,
-                        uiState.buyDate.day
-                    ),
-                    onClickBuyDate = onClickBuyDate
-                )
-                AssetConfirmButton(
-                    buttonTextId = buttonTextId,
-                    onClickConfirm = { onClickConfirm(assetName) }
+                    onClickConfirm = { onClickConfirm(uiState.asset.name) }
                 )
             }
         }
@@ -118,8 +77,9 @@ internal fun AssetContent(
 @Composable
 private fun AssetContentPreview() {
     AssetContent(
-        uiState = AssetUiState.AddAssetInitial,
+        uiState = AssetUiState.Error,
         buttonTextId = R.string.save,
+        onAssetNameChange = {},
         onClickBuyDate = {},
         onClickConfirm = {}
     )

--- a/feature/asset/src/main/java/com/sdhong/jonbeowin/feature/asset/uistate/AssetUiState.kt
+++ b/feature/asset/src/main/java/com/sdhong/jonbeowin/feature/asset/uistate/AssetUiState.kt
@@ -1,16 +1,12 @@
 package com.sdhong.jonbeowin.feature.asset.uistate
 
 import com.sdhong.jonbeowin.feature.asset.model.AssetModel
-import com.sdhong.jonbeowin.feature.asset.model.BuyDateModel
 
 sealed interface AssetUiState {
 
     data object Idle : AssetUiState
 
-    data class AssetDetailInitial(val initialAsset: AssetModel) : AssetUiState
-    data object AddAssetInitial : AssetUiState
-
-    data class AssetDateSelected(val buyDate: BuyDateModel) : AssetUiState
+    data class Success(val asset: AssetModel) : AssetUiState
 
     data object Error : AssetUiState
 }

--- a/feature/asset/src/main/java/com/sdhong/jonbeowin/feature/asset/view/AssetFragment.kt
+++ b/feature/asset/src/main/java/com/sdhong/jonbeowin/feature/asset/view/AssetFragment.kt
@@ -55,6 +55,7 @@ class AssetFragment : BaseFragment<FragmentAssetBinding>(
             AssetContent(
                 uiState = uiState,
                 buttonTextId = if (viewModel.isAssetDetail) R.string.fix else R.string.save,
+                onAssetNameChange = viewModel::setAssetName,
                 onClickBuyDate = {
                     val calendar = Calendar.getInstance()
 

--- a/feature/asset/src/main/java/com/sdhong/jonbeowin/feature/asset/viewmodel/AssetViewModel.kt
+++ b/feature/asset/src/main/java/com/sdhong/jonbeowin/feature/asset/viewmodel/AssetViewModel.kt
@@ -1,6 +1,7 @@
 package com.sdhong.jonbeowin.feature.asset.viewmodel
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import com.sdhong.jonbeowin.core.common.base.BaseViewModel
 import com.sdhong.jonbeowin.core.domain.usecase.GetAssetUseCase
 import com.sdhong.jonbeowin.core.domain.usecase.UpdateAssetUseCase
@@ -15,8 +16,9 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import java.util.Calendar
@@ -33,35 +35,27 @@ class AssetViewModel @Inject constructor(
 
     val isAssetDetail = assetId != 0
 
-    private val initialAsset = getAssetUseCase(assetId)
-        .map { it.toPresentation() }
-        .catch {
-            emit(AssetModel.Default)
-        }
-        .stateIn(
-            initialValue = AssetModel.Default
-        )
-    private val buyDate = MutableStateFlow(BuyDateModel.Default)
+    private val asset: MutableStateFlow<AssetModel> = MutableStateFlow(AssetModel.Default)
 
-    val uiState: StateFlow<AssetUiState> = combine(
-        initialAsset,
-        buyDate
-    ) { initialAsset, buyDate ->
-        if (buyDate == BuyDateModel.Default) {
-            if (isAssetDetail) {
-                setBuyDate(initialAsset.buyDate.year, initialAsset.buyDate.month, initialAsset.buyDate.day)
-                AssetUiState.AssetDetailInitial(initialAsset)
-            } else {
-                AssetUiState.AddAssetInitial
-            }
-        } else {
-            AssetUiState.AssetDateSelected(buyDate)
-        }
+    private val _uiState: MutableStateFlow<AssetUiState> = MutableStateFlow(AssetUiState.Idle)
+    val uiState: StateFlow<AssetUiState> = asset.map<AssetModel, AssetUiState> {
+        AssetUiState.Success(it)
     }.catch {
         emit(AssetUiState.Error)
-    }.stateIn(
-        initialValue = AssetUiState.Idle
-    )
+    }.stateIn(AssetUiState.Idle)
+
+    init {
+        if (isAssetDetail) {
+            getAssetUseCase(assetId)
+                .onEach {
+                    asset.value = it.toPresentation()
+                }
+                .catch {
+                    _uiState.value = AssetUiState.Error
+                }
+                .launchIn(viewModelScope)
+        }
+    }
 
     private val _eventChannel = Channel<AssetEvent>(Channel.BUFFERED)
     val eventFlow = _eventChannel.receiveAsFlow()
@@ -76,17 +70,17 @@ class AssetViewModel @Inject constructor(
             if (validateDiffDays(diffDays)) return@launch
 
             val updatedAsset = if (isAssetDetail) {
-                initialAsset.value.copy(
+                asset.value.copy(
                     name = updatedName,
                     dayCount = diffDays + 1,
-                    buyDate = buyDate.value
+                    buyDate = asset.value.buyDate
                 )
             } else {
                 AssetModel(
                     id = 0,
                     name = updatedName,
                     dayCount = diffDays + 1,
-                    buyDate = buyDate.value,
+                    buyDate = asset.value.buyDate,
                     createdAt = Calendar.getInstance().time.toString()
                 )
             }
@@ -106,7 +100,7 @@ class AssetViewModel @Inject constructor(
     }
 
     private suspend fun checkUserSetBuyDate(): Boolean {
-        if (buyDate.value == BuyDateModel.Default) {
+        if (asset.value.buyDate == BuyDateModel.Default) {
             _eventChannel.send(AssetEvent.ShowToast(AssetToast.ASSET_BUY_DATE_EMPTY))
             return true
         }
@@ -115,7 +109,7 @@ class AssetViewModel @Inject constructor(
 
     private fun getDiffDays(): Int {
         val buyDay = Calendar.getInstance().apply {
-            set(buyDate.value.year, buyDate.value.month - 1, buyDate.value.day, 0, 0, 0)
+            set(asset.value.buyDate.year, asset.value.buyDate.month - 1, asset.value.buyDate.day, 0, 0, 0)
             set(Calendar.MILLISECOND, 0)
         }.timeInMillis
         val today = Calendar.getInstance().apply {
@@ -136,11 +130,17 @@ class AssetViewModel @Inject constructor(
         return false
     }
 
+    fun setAssetName(name: String) {
+        asset.value = asset.value.copy(name = name)
+    }
+
     fun setBuyDate(year: Int, month: Int, day: Int) {
-        buyDate.value = BuyDateModel(
-            year = year,
-            month = month,
-            day = day
+        asset.value = asset.value.copy(
+            buyDate = BuyDateModel(
+                year = year,
+                month = month,
+                day = day
+            )
         )
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #27 

## 📝 작업 내용

- initialAsset은 제거하고, asset과 uiState 정의하여 ViewModel 로직 수정
- AssetUiState를 Idle, Success, Error로 축소
- 자산 상세 화면으로 진입했을 때 자산명 TextField에 자산명이 입력되어 있지 않은 버그 수정
